### PR TITLE
Upgrade Python support to 3.10–3.15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install uv
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-test clean-pyc clean-build docs help
+.PHONY: clean clean-test clean-pyc clean-build docs help test-all-python
 .DEFAULT_GOAL := help
 
 define BROWSER_PYSCRIPT
@@ -42,7 +42,7 @@ lint:
 	uv run ruff check --fix .
 	uv run ruff format .
 	uv run mypy --version
-	uv run mypy --python-version '3.12' --pretty --config-file pyproject.toml src
+	uv run mypy --python-version '3.10' --pretty --config-file pyproject.toml src
 	@echo "${GREEN}✅ Lint checks passed!${NOCOLOR}"
 
 test: ## run tests quickly with the default Python
@@ -50,6 +50,13 @@ test: ## run tests quickly with the default Python
 	uv run pytest --force-sugar -vvv
 
 test-all: lint test
+
+test-all-python: ## run tests against all supported Python versions
+	@for version in 3.10 3.11 3.12 3.13 3.14 3.15; do \
+		echo "${GREEN}🧪 Testing Python $$version...${NOCOLOR}"; \
+		uv run --python $$version pytest --force-sugar -vvv || exit 1; \
+	done
+	@echo "${GREEN}✅ All Python versions passed!${NOCOLOR}"
 
 pre-commit:
 	@echo "${GREEN}🔨 Running pre-commit hooks...${NOCOLOR}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
+    'Programming Language :: Python :: 3.15',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
     'Topic :: Software Development :: Libraries :: Python Modules',
@@ -49,8 +51,8 @@ no_implicit_reexport = true
 
 
 [tool.ruff]
-# Always generate Python 3.11-compatible code.
-target-version = "py38"
+# Always generate Python 3.10-compatible code.
+target-version = "py310"
 exclude = [".venv"]
 fix = true
 lint.select = ["ALL"]

--- a/src/sleepfake/__init__.py
+++ b/src/sleepfake/__init__.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import datetime
+import sys
 import time
 from unittest.mock import patch
 
 import freezegun
 
-try:
-    from typing import Self  # Python 3.11+
-except ImportError:
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
     from typing_extensions import Self
 
 
@@ -28,7 +29,7 @@ class SleepFake:
 
     def __init__(self) -> None:
         self.sleep = time.sleep
-        self.freeze_time = freezegun.freeze_time(datetime.datetime.now(tz=datetime.UTC))
+        self.freeze_time = freezegun.freeze_time(datetime.datetime.now(tz=datetime.timezone.utc))
         self.frozen_factory = self.freeze_time.start()
         self.time_patch = patch("time.sleep", side_effect=self.mock_sleep)
         self.asyncio_patch = patch("asyncio.sleep", side_effect=self.amock_sleep)

--- a/src/sleepfake/plugin.py
+++ b/src/sleepfake/plugin.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 


### PR DESCRIPTION
# Upgrade Python support to 3.10–3.15

## Summary

Extends the supported Python version matrix from `3.10–3.13` to `3.10–3.15`, fixing compatibility issues and modernising CI/tooling.

## Changes

### Source code (`src/sleepfake/__init__.py`)
- Replaced `try/except ImportError` shim for `Self` with a `sys.version_info >= (3, 11)` guard — the mypy-safe pattern for conditional imports
- Replaced `datetime.UTC` (Python 3.11+) with `datetime.timezone.utc` to restore Python 3.10 compatibility

### `pyproject.toml`
- Added `Programming Language :: Python :: 3.14` and `3.15` classifiers
- Fixed `[tool.ruff] target-version` from `"py38"` to `"py310"` (matches the actual minimum)

### `.github/workflows/test.yml`
- Expanded matrix: `["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]`
- Added `allow-prereleases: true` on `setup-python` (required for 3.15 pre-release)
- Upgraded `actions/checkout@v3` → `v4`
- Upgraded `actions/setup-python@v3` → `v5`

### `.github/workflows/release.yml`
- Upgraded `actions/checkout@v2` → `v4`
- Upgraded `actions/setup-python@v4` → `v5`

### `Makefile`
- Updated `mypy --python-version` from `3.12` to `3.10` (type-check against the minimum supported version)
- Added `test-all-python` target — loops through all supported versions via `uv run --python 3.X`

## Testing

```bash
make lint        # ruff + mypy — passes cleanly
make test        # 6/6 tests pass
make test-all-python  # runs pytest under each Python version locally
```

Pre-install all interpreters with:
```bash
uv python install 3.10 3.11 3.12 3.13 3.14 3.15
```
