### PR TITLE
 feat: async fixture, marker, and global autouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ async def test_async():
 
 ### As a pytest fixture
 
-Install once; the `sleepfake` and `asleepfake` fixtures are available in every test session automatically.
+Install once; the `sleepfake` fixture is available in every test session automatically.
 
-**`sleepfake`** (sync fixture):
+**`sleepfake`** — works for both sync *and* async tests:
 
 ```python
 import time
@@ -65,12 +65,10 @@ def test_retry_logic(sleepfake):
     assert time.time() - start >= 30
 ```
 
-**`asleepfake`** (async fixture — recommended for async tests; properly awaits the background processor task on teardown):
-
 ```python
 import asyncio
 
-async def test_polling(asleepfake):
+async def test_polling(sleepfake):
     start = asyncio.get_running_loop().time()
     await asyncio.gather(
         asyncio.sleep(1),
@@ -80,6 +78,8 @@ async def test_polling(asleepfake):
     # All three complete instantly; frozen clock sits at +5 s
     assert asyncio.get_running_loop().time() - start >= 5
 ```
+
+> **Deprecated:** The `asleepfake` async fixture is deprecated. Use `sleepfake` instead — it initialises the async sleep-processor lazily on the first `asyncio.sleep` call and works identically in async tests.
 
 ### As a marker
 
@@ -104,7 +104,7 @@ async def test_marked_async():
     assert asyncio.get_running_loop().time() - start >= 100
 ```
 
-> If a test requests the `sleepfake` or `asleepfake` fixture *and* carries the marker, the marker is a no-op — double-patching is prevented automatically.
+> If a test requests the `sleepfake` fixture *and* carries the marker, the marker is a no-op — double-patching is prevented automatically.
 
 ### Global autouse (every test, zero boilerplate)
 
@@ -139,7 +139,7 @@ async def test_async_no_decoration():
     assert asyncio.get_running_loop().time() - start >= 100
 ```
 
-Double-patching is prevented: if a test also requests the `sleepfake`/`asleepfake` fixture or carries `@pytest.mark.sleepfake`, the autouse layer is skipped for that test.
+Double-patching is prevented: if a test also requests the `sleepfake` fixture or carries `@pytest.mark.sleepfake`, the autouse layer is skipped for that test.
 
 **Option C — conftest.py autouse fixtures** (if you need finer control per directory):
 

--- a/README.md
+++ b/README.md
@@ -5,51 +5,21 @@
 <p align="center">
   <a href="https://pypi.org/project/sleepfake/"><img src="https://img.shields.io/pypi/v/sleepfake.svg?color=blue" alt="PyPI version"></a>
   <a href="https://github.com/spulec/freezegun"><img src="https://img.shields.io/badge/dependency-freezegun-blue" alt="freezegun"></a>
-  <img src="https://img.shields.io/badge/pytest%20fixture-alpha-orange" alt="pytest fixture alpha"/>
+  <img src="https://img.shields.io/badge/pytest%20plugin-stable-green" alt="pytest plugin stable"/>
 </p>
 
 # 💤 SleepFake: Time Travel for Your Tests
 
-Ever wish your tests could skip the wait? **SleepFake** lets you fake `time.sleep` and `asyncio.sleep` so your tests run at lightning speed—no more wasting time waiting for the clock!
+Ever wish your tests could skip the wait? **SleepFake** patches `time.sleep` and `asyncio.sleep` so your tests run instantly—the frozen clock advances by the requested duration, so all your time-based assertions still hold.
 
 ## 🚀 Features
 
 - Instantly skip over `sleep` calls in both sync and async code
 - Works with `time.sleep` and `asyncio.sleep`
-- Compatible with pytest and pytest-asyncio
-- Supports context manager and async context manager usage
-- No more slow tests—get results fast!
-
-## ✨ Example Usage
-
-```python
-from sleepfake import SleepFake
-import time
-import asyncio
-
-# Synchronous example
-with SleepFake():
-    start = time.time()
-    time.sleep(10)  # Instantly skipped!
-    end = time.time()
-    print(f"Elapsed: {end - start:.2f}s")  # Elapsed: 10.00s
-
-# Asynchronous example
-async def main():
-    async with SleepFake():
-        start = asyncio.get_event_loop().time()
-        await asyncio.sleep(5)  # Instantly skipped!
-        end = asyncio.get_event_loop().time()
-        print(f"Elapsed: {end - start:.2f}s")  # Elapsed: 5.00s
-
-asyncio.run(main())
-```
-
-## 🧪 Why Use SleepFake?
-
-- **Speed up your test suite**: No more real waiting!
-- **Test time-based logic**: Simulate long waits, retries, and timeouts instantly.
-- **Fun to use**: Who doesn't love time travel?
+- Concurrent async sleeps wake in deadline order (priority queue)
+- `asyncio.timeout` / `asyncio.TaskGroup` work correctly with frozen time
+- Three ways to use: **context manager**, **pytest fixture**, or **marker**
+- Compatible with pytest, pytest-asyncio, and pytest-timeout
 
 ## 📦 Installation
 
@@ -57,9 +27,120 @@ asyncio.run(main())
 pip install sleepfake
 ```
 
+## ✨ Usage
+
+### As a context manager
+
+```python
+import time
+import asyncio
+from sleepfake import SleepFake
+
+# Sync — frozen clock advances, wall clock doesn't
+with SleepFake():
+    start = time.time()
+    time.sleep(10)           # returns instantly
+    assert time.time() - start >= 10  # frozen clock advanced
+
+# Async — use async with for proper cleanup of the background processor
+async def test_async():
+    async with SleepFake():
+        start = asyncio.get_running_loop().time()
+        await asyncio.sleep(5)   # returns instantly
+        assert asyncio.get_running_loop().time() - start >= 5
+```
+
+### As a pytest fixture
+
+Install once; the `sleepfake` and `asleepfake` fixtures are available in every test session automatically.
+
+**`sleepfake`** (sync fixture — fine for sync tests and simple async tests):
+
+```python
+import time
+
+def test_retry_logic(sleepfake):
+    start = time.time()
+    time.sleep(30)           # instantly skipped
+    assert time.time() - start >= 30
+```
+
+**`asleepfake`** (async fixture — recommended for async-heavy tests; properly awaits the background processor task on teardown):
+
+```python
+import asyncio
+
+async def test_polling(asleepfake):
+    start = asyncio.get_running_loop().time()
+    await asyncio.gather(
+        asyncio.sleep(1),
+        asyncio.sleep(5),
+        asyncio.sleep(3),
+    )
+    # All three complete instantly; frozen clock sits at +5 s
+    assert asyncio.get_running_loop().time() - start >= 5
+```
+
+### As a marker
+
+Decorate individual tests with `@pytest.mark.sleepfake` — no fixture argument needed.
+SleepFake is entered before the test body and exited after, automatically.
+
+```python
+import time
+import asyncio
+import pytest
+
+@pytest.mark.sleepfake
+def test_marked_sync():
+    start = time.time()
+    time.sleep(100)
+    assert time.time() - start >= 100
+
+@pytest.mark.sleepfake
+async def test_marked_async():
+    start = asyncio.get_running_loop().time()
+    await asyncio.sleep(100)
+    assert asyncio.get_running_loop().time() - start >= 100
+```
+
+> If a test requests the `sleepfake` or `asleepfake` fixture *and* carries the marker, the marker is a no-op — double-patching is prevented automatically.
+
+### `asyncio.timeout` integration
+
+The frozen clock is advanced before resolving each sleep future, so `asyncio.timeout` fires correctly even when time is faked:
+
+```python
+import asyncio
+import pytest
+from sleepfake import SleepFake
+
+async def test_timeout_fires():
+    with SleepFake():
+        with pytest.raises(TimeoutError):
+            async with asyncio.timeout(2):
+                await asyncio.sleep(10)   # clock jumps to +10 s → timeout at +2 s fires
+```
+
+## ⚠️ Scope limitation
+
+SleepFake patches `time.sleep` and `asyncio.sleep` by name via `unittest.mock.patch`.
+Code that binds the function locally **before** the context is entered — e.g.
+`from time import sleep` at module level — will bypass the mock.
+
+## 🧪 How it works
+
+| Aspect | Detail |
+|---|---|
+| **Sync sleep** | `frozen_factory.tick(delta)` — advances the freeze-gun clock immediately |
+| **Async sleep** | `(deadline, seq, future)` pushed onto an `asyncio.PriorityQueue`; background task resolves futures in deadline order |
+| **Timeout safety** | After advancing the clock, the processor yields one event-loop iteration so `asyncio.timeout` call-at callbacks can fire before futures are resolved |
+| **Cancellation** | Cancelled futures are skipped; `process_sleeps` keeps running |
+| **pytest durations** | `_pytest.timing.perf_counter` is restored after `freeze_time.start()` to prevent epoch-scale `--durations` output |
+
 ## 🤝 Contributing
 
-PRs and issues welcome! Help make testing even more fun.
+PRs and issues welcome!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ import time
 import asyncio
 from sleepfake import SleepFake
 
-# Sync — frozen clock advances, wall clock doesn't
+# Sync
 with SleepFake():
     start = time.time()
     time.sleep(10)           # returns instantly
-    assert time.time() - start >= 10  # frozen clock advanced
+    assert time.time() - start >= 10
 
 # Async — use async with for proper cleanup of the background processor
 async def test_async():
@@ -54,7 +54,7 @@ async def test_async():
 
 Install once; the `sleepfake` and `asleepfake` fixtures are available in every test session automatically.
 
-**`sleepfake`** (sync fixture — fine for sync tests and simple async tests):
+**`sleepfake`** (sync fixture):
 
 ```python
 import time
@@ -65,7 +65,7 @@ def test_retry_logic(sleepfake):
     assert time.time() - start >= 30
 ```
 
-**`asleepfake`** (async fixture — recommended for async-heavy tests; properly awaits the background processor task on teardown):
+**`asleepfake`** (async fixture — recommended for async tests; properly awaits the background processor task on teardown):
 
 ```python
 import asyncio
@@ -105,6 +105,58 @@ async def test_marked_async():
 ```
 
 > If a test requests the `sleepfake` or `asleepfake` fixture *and* carries the marker, the marker is a no-op — double-patching is prevented automatically.
+
+### Global autouse (every test, zero boilerplate)
+
+**Option A — config file** (`pyproject.toml` or `pytest.ini`):
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+sleepfake_autouse = true
+```
+
+**Option B — CLI flag** (useful for one-off runs or CI overrides):
+
+```bash
+pytest --sleepfake
+```
+
+Both activate SleepFake automatically for every test in the session:
+
+```python
+import time
+import asyncio
+
+def test_no_decoration_needed():
+    start = time.time()
+    time.sleep(100)          # patched automatically
+    assert time.time() - start >= 100
+
+async def test_async_no_decoration():
+    start = asyncio.get_running_loop().time()
+    await asyncio.sleep(100)
+    assert asyncio.get_running_loop().time() - start >= 100
+```
+
+Double-patching is prevented: if a test also requests the `sleepfake`/`asleepfake` fixture or carries `@pytest.mark.sleepfake`, the autouse layer is skipped for that test.
+
+**Option C — conftest.py autouse fixtures** (if you need finer control per directory):
+
+```python
+# conftest.py
+import pytest
+
+@pytest.fixture(autouse=True)
+def _sleepfake_sync(sleepfake):
+    """Auto-apply SleepFake for every test (sync and async)."""
+
+@pytest.fixture(autouse=True)
+async def _sleepfake_async(sleepfake):
+    """Async counterpart — shares the same sleepfake instance; no double-patch."""
+```
+
+Both fixtures reference the same `sleepfake` instance: sync tests get `_sleepfake_sync` only, async tests get both but share one `SleepFake` (no double-patch).
 
 ### `asyncio.timeout` integration
 

--- a/src/sleepfake/__init__.py
+++ b/src/sleepfake/__init__.py
@@ -29,7 +29,13 @@ _QueueItem = tuple[datetime.datetime, int, asyncio.Future[None]]
 
 
 class SleepFake:
-    """Fake the time.sleep/asyncio.sleep function during tests."""
+    """Fake the time.sleep/asyncio.sleep function during tests.
+
+    Note:
+        Uses ``unittest.mock.patch("time.sleep")`` / ``patch("asyncio.sleep")``.
+        Code that binds the function locally (``from time import sleep``) before
+        the context is entered will bypass the mock.
+    """
 
     def __init__(self) -> None:
         self.freeze_time = freezegun.freeze_time(datetime.datetime.now(tz=datetime.timezone.utc))
@@ -43,8 +49,27 @@ class SleepFake:
 
     def _start_freeze(self) -> None:
         if not self._freeze_started:
+            # Capture _pytest.timing.perf_counter *before* starting the freeze.
+            # Freezegun's to_patch mechanism scans sys.modules and replaces every
+            # module attribute equal to the real perf_counter with its frozen stub,
+            # including _pytest.timing.perf_counter which pytest uses to compute
+            # --durations. Restoring it causes pytest to keep using the real
+            # boot-relative clock, so reported durations stay near zero.
+            _timing_module = None
+            _real_pc = None
+            try:
+                import _pytest.timing  # noqa: PLC0415
+
+                _timing_module = _pytest.timing
+                _real_pc = _pytest.timing.perf_counter
+            except ImportError:
+                pass
+
             self.frozen_factory = self.freeze_time.start()
             self._freeze_started = True
+
+            if _timing_module is not None:
+                _timing_module.perf_counter = _real_pc  # type: ignore[assignment]
 
     def _stop_freeze(self) -> None:
         if self._freeze_started:

--- a/src/sleepfake/plugin.py
+++ b/src/sleepfake/plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import pytest
@@ -12,17 +13,30 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def sleepfake() -> Generator[SleepFake, None, None]:
-    """Sync fixture — enters SleepFake via ``__enter__``/``__exit__``."""
+    """Pytest fixture — works for both sync and async tests.
+
+    Enters SleepFake via ``__enter__``/``__exit__``.  Inside an async test
+    the lazy ``_init_async_patch`` call initialises the priority-queue and
+    processor on the first ``asyncio.sleep`` call, so no async fixture is
+    needed.
+    """
     with SleepFake() as sf:
         yield sf
 
 
 @pytest.fixture
 async def asleepfake() -> AsyncGenerator[SleepFake, None]:
-    """Async fixture — enters SleepFake via ``__aenter__``/``__aexit__``.
+    """*Deprecated* — use the ``sleepfake`` fixture instead.
 
-    Properly awaits the background sleep-processor task on teardown.
+    ``sleepfake`` now works transparently in both sync and async tests.
+    ``asleepfake`` will be removed in a future release.
     """
+    warnings.warn(
+        "The 'asleepfake' fixture is deprecated and will be removed in a future release. "
+        "Use the 'sleepfake' fixture instead — it works for both sync and async tests.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     async with SleepFake() as sf:
         yield sf
 
@@ -72,9 +86,9 @@ class _AutouseSleepFakePlugin:
 
     Uses setup/teardown hooks (not autouse fixtures) so exactly one SleepFake
     context is entered per test, regardless of sync vs async, without touching
-    the fixture discovery machinery.  Tests that already use the
-    ``sleepfake``/``asleepfake`` fixture or ``@pytest.mark.sleepfake`` are
-    skipped to avoid double-patching.
+    the fixture discovery machinery.  Tests that already use the ``sleepfake``
+    fixture (or the deprecated ``asleepfake``) or ``@pytest.mark.sleepfake``
+    are skipped to avoid double-patching.
     """
 
     _ATTR = "_sleepfake_autouse_sf"
@@ -108,8 +122,8 @@ _MARKER_ATTR = "_sleepfake_marker_sf"
 def pytest_runtest_setup(item: pytest.Item) -> None:
     """Enter a SleepFake context for tests decorated with ``@pytest.mark.sleepfake``.
 
-    Skipped when the test already requests the ``sleepfake`` or ``asleepfake``
-    fixture to avoid double-patching.
+    Skipped when the test already requests the ``sleepfake`` fixture (or the
+    deprecated ``asleepfake``) to avoid double-patching.
     """
     if not list(item.iter_markers(name="sleepfake")):
         return

--- a/src/sleepfake/plugin.py
+++ b/src/sleepfake/plugin.py
@@ -1,16 +1,71 @@
-from collections.abc import Generator
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pytest
 
 from sleepfake import SleepFake
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Generator
+
 
 @pytest.fixture
 def sleepfake() -> Generator[SleepFake, None, None]:
-    with SleepFake() as sleepfake_:
-        yield sleepfake_
+    """Sync fixture — enters SleepFake via ``__enter__``/``__exit__``."""
+    with SleepFake() as sf:
+        yield sf
+
+
+@pytest.fixture
+async def asleepfake() -> AsyncGenerator[SleepFake, None]:
+    """Async fixture — enters SleepFake via ``__aenter__``/``__aexit__``.
+
+    Properly awaits the background sleep-processor task on teardown.
+    """
+    async with SleepFake() as sf:
+        yield sf
+
+
+# ---------------------------------------------------------------------------
+# @pytest.mark.sleepfake — auto-apply SleepFake to marked tests
+# ---------------------------------------------------------------------------
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Inject documentation."""
-    config.addinivalue_line("markers", "sleepfake: mark test to run with SleepFake context manager")
+    """Register the ``sleepfake`` marker."""
+    config.addinivalue_line(
+        "markers",
+        "sleepfake: automatically patch time.sleep/asyncio.sleep with SleepFake",
+    )
+
+
+_SLEEPFAKE_ATTR = "_sleepfake_instance"
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Enter a SleepFake context for tests decorated with ``@pytest.mark.sleepfake``.
+
+    Skipped when the test already requests the ``sleepfake`` or ``asleepfake``
+    fixture to avoid double-patching.
+    """
+    if not list(item.iter_markers(name="sleepfake")):
+        return
+
+    # Avoid double-patching when the fixture is also requested.
+    fixturenames: list[str] = getattr(item, "fixturenames", [])
+    if "sleepfake" in fixturenames or "asleepfake" in fixturenames:
+        return
+
+    sf = SleepFake()
+    sf.__enter__()
+    setattr(item, _SLEEPFAKE_ATTR, sf)
+
+
+def pytest_runtest_teardown(item: pytest.Item) -> None:
+    """Exit the SleepFake context opened by the marker hook."""
+    sf: SleepFake | None = getattr(item, _SLEEPFAKE_ATTR, None)
+    if sf is not None:
+        sf.__exit__(None, None, None)
+        delattr(item, _SLEEPFAKE_ATTR)

--- a/src/sleepfake/plugin.py
+++ b/src/sleepfake/plugin.py
@@ -28,19 +28,80 @@ async def asleepfake() -> AsyncGenerator[SleepFake, None]:
 
 
 # ---------------------------------------------------------------------------
-# @pytest.mark.sleepfake — auto-apply SleepFake to marked tests
+# sleepfake_autouse ini option  /  --sleepfake CLI flag
 # ---------------------------------------------------------------------------
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the ``sleepfake_autouse`` ini option and ``--sleepfake`` CLI flag."""
+    parser.addini(
+        "sleepfake_autouse",
+        help="Apply SleepFake automatically to every test in the session.",
+        type="bool",
+        default=False,
+    )
+    parser.addoption(
+        "--sleepfake",
+        action="store_true",
+        default=False,
+        help="Apply SleepFake automatically to every test (same as sleepfake_autouse = true).",
+    )
+
+
+def _autouse_enabled(config: pytest.Config) -> bool:
+    if config.getini("sleepfake_autouse"):
+        return True
+    try:
+        return bool(config.getoption("sleepfake"))
+    except (ValueError, AttributeError):
+        return False
+
+
 def pytest_configure(config: pytest.Config) -> None:
-    """Register the ``sleepfake`` marker."""
+    """Register the ``sleepfake`` marker and optionally enable autouse mode."""
     config.addinivalue_line(
         "markers",
         "sleepfake: automatically patch time.sleep/asyncio.sleep with SleepFake",
     )
+    if _autouse_enabled(config):
+        config.pluginmanager.register(_AutouseSleepFakePlugin(), "sleepfake-autouse")
 
 
-_SLEEPFAKE_ATTR = "_sleepfake_instance"
+class _AutouseSleepFakePlugin:
+    """Registered when ``sleepfake_autouse = true`` or ``--sleepfake`` is passed.
+
+    Uses setup/teardown hooks (not autouse fixtures) so exactly one SleepFake
+    context is entered per test, regardless of sync vs async, without touching
+    the fixture discovery machinery.  Tests that already use the
+    ``sleepfake``/``asleepfake`` fixture or ``@pytest.mark.sleepfake`` are
+    skipped to avoid double-patching.
+    """
+
+    _ATTR = "_sleepfake_autouse_sf"
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_runtest_setup(self, item: pytest.Item) -> None:
+        fixturenames: list[str] = getattr(item, "fixturenames", [])
+        if "sleepfake" in fixturenames or "asleepfake" in fixturenames:
+            return
+        if list(item.iter_markers(name="sleepfake")):
+            return
+        sf = SleepFake()
+        sf.__enter__()
+        setattr(item, _AutouseSleepFakePlugin._ATTR, sf)
+
+    def pytest_runtest_teardown(self, item: pytest.Item) -> None:
+        sf: SleepFake | None = getattr(item, _AutouseSleepFakePlugin._ATTR, None)
+        if sf is not None:
+            sf.__exit__(None, None, None)
+            delattr(item, _AutouseSleepFakePlugin._ATTR)
+
+
+# ---------------------------------------------------------------------------
+# @pytest.mark.sleepfake — auto-apply SleepFake to marked tests
+# ---------------------------------------------------------------------------
+
+_MARKER_ATTR = "_sleepfake_marker_sf"
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -52,20 +113,17 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
     """
     if not list(item.iter_markers(name="sleepfake")):
         return
-
-    # Avoid double-patching when the fixture is also requested.
     fixturenames: list[str] = getattr(item, "fixturenames", [])
     if "sleepfake" in fixturenames or "asleepfake" in fixturenames:
         return
-
     sf = SleepFake()
     sf.__enter__()
-    setattr(item, _SLEEPFAKE_ATTR, sf)
+    setattr(item, _MARKER_ATTR, sf)
 
 
 def pytest_runtest_teardown(item: pytest.Item) -> None:
     """Exit the SleepFake context opened by the marker hook."""
-    sf: SleepFake | None = getattr(item, _SLEEPFAKE_ATTR, None)
+    sf: SleepFake | None = getattr(item, _MARKER_ATTR, None)
     if sf is not None:
         sf.__exit__(None, None, None)
-        delattr(item, _SLEEPFAKE_ATTR)
+        delattr(item, _MARKER_ATTR)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -313,13 +313,13 @@ async def test_fixture_async_gather(sleepfake: SleepFake) -> None:  # noqa: ARG0
 
 
 # ---------------------------------------------------------------------------
-# Async fixture (asleepfake) — proper aclose() cleanup
+# sleepfake fixture in async tests (covers deprecated asleepfake use-cases)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_async_fixture_sleep(asleepfake: SleepFake) -> None:  # noqa: ARG001
-    """The async ``asleepfake`` fixture works for basic sleep."""
+async def test_async_fixture_sleep(sleepfake: SleepFake) -> None:  # noqa: ARG001
+    """The ``sleepfake`` fixture works for basic async sleep."""
     start = asyncio.get_running_loop().time()
     await asyncio.sleep(SLEEP_DURATION)
     end = asyncio.get_running_loop().time()
@@ -327,8 +327,8 @@ async def test_async_fixture_sleep(asleepfake: SleepFake) -> None:  # noqa: ARG0
 
 
 @pytest.mark.asyncio
-async def test_async_fixture_gather(asleepfake: SleepFake) -> None:  # noqa: ARG001
-    """Concurrent gathers work through the async fixture."""
+async def test_async_fixture_gather(sleepfake: SleepFake) -> None:  # noqa: ARG001
+    """Concurrent gathers work through the ``sleepfake`` fixture in an async test."""
     start = asyncio.get_running_loop().time()
     await asyncio.gather(
         asyncio.sleep(SLEEP_DURATION),
@@ -340,9 +340,9 @@ async def test_async_fixture_gather(asleepfake: SleepFake) -> None:  # noqa: ARG
 
 
 @pytest.mark.asyncio
-async def test_async_fixture_cleanup(asleepfake: SleepFake) -> None:
-    """After the async fixture yields, processor and queue are cleaned up."""
+async def test_async_fixture_cleanup(sleepfake: SleepFake) -> None:
+    """While the fixture is active the processor and queue are initialised."""
     await asyncio.sleep(1)
-    # While inside the fixture, processor should be running.
-    assert asleepfake.sleep_processor is not None
-    assert asleepfake.sleep_queue is not None
+    # Lazy init on first amock_sleep — processor must be running now.
+    assert sleepfake.sleep_processor is not None
+    assert sleepfake.sleep_queue is not None

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -284,3 +284,65 @@ async def test_async_gather_equal_durations():
         await asyncio.gather(tagged(1), tagged(2), tagged(3))
 
     assert sorted(results) == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Fixture-based async tests (sync fixture in async test)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fixture_async_sleep(sleepfake: SleepFake) -> None:  # noqa: ARG001
+    """The sync ``sleepfake`` fixture works inside an async test."""
+    start = asyncio.get_running_loop().time()
+    await asyncio.sleep(SLEEP_DURATION)
+    end = asyncio.get_running_loop().time()
+    assert end - start >= SLEEP_DURATION
+
+
+@pytest.mark.asyncio
+async def test_fixture_async_gather(sleepfake: SleepFake) -> None:  # noqa: ARG001
+    """Concurrent gathers work through the sync fixture."""
+    start = asyncio.get_running_loop().time()
+    await asyncio.gather(
+        asyncio.sleep(SLEEP_DURATION),
+        asyncio.sleep(SLEEP_DURATION),
+    )
+    end = asyncio.get_running_loop().time()
+    assert SLEEP_DURATION <= end - start <= SLEEP_DURATION + 0.5
+
+
+# ---------------------------------------------------------------------------
+# Async fixture (asleepfake) — proper aclose() cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_fixture_sleep(asleepfake: SleepFake) -> None:  # noqa: ARG001
+    """The async ``asleepfake`` fixture works for basic sleep."""
+    start = asyncio.get_running_loop().time()
+    await asyncio.sleep(SLEEP_DURATION)
+    end = asyncio.get_running_loop().time()
+    assert end - start >= SLEEP_DURATION
+
+
+@pytest.mark.asyncio
+async def test_async_fixture_gather(asleepfake: SleepFake) -> None:  # noqa: ARG001
+    """Concurrent gathers work through the async fixture."""
+    start = asyncio.get_running_loop().time()
+    await asyncio.gather(
+        asyncio.sleep(SLEEP_DURATION),
+        asyncio.sleep(SLEEP_DURATION),
+        asyncio.sleep(SLEEP_DURATION),
+    )
+    end = asyncio.get_running_loop().time()
+    assert SLEEP_DURATION <= end - start <= SLEEP_DURATION + 0.5
+
+
+@pytest.mark.asyncio
+async def test_async_fixture_cleanup(asleepfake: SleepFake) -> None:
+    """After the async fixture yields, processor and queue are cleaned up."""
+    await asyncio.sleep(1)
+    # While inside the fixture, processor should be running.
+    assert asleepfake.sleep_processor is not None
+    assert asleepfake.sleep_queue is not None

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 import sys
 import time
 
@@ -80,6 +81,32 @@ def test_sync_reentrant_context():
         assert time.time() - real_start < 1
 
 
+def test_durations_not_epoch_scale(pytester: pytest.Pytester) -> None:
+    """Pytest --durations must not show epoch-scale values when sleepfake is active.
+
+    Freezegun's to_patch mechanism replaces _pytest.timing.perf_counter with a
+    frozen stub, producing multi-billion-second durations.  SleepFake must restore
+    the real function after freeze_time.start() so pytest's timer keeps ticking.
+    """
+    pytester.makepyfile("""
+        import pytest
+
+        @pytest.fixture(autouse=True)
+        def _use_sleepfake(sleepfake):
+            pass
+
+        def test_with_fake_sleep():
+            pass
+    """)
+    result = pytester.runpytest_subprocess("--durations", "1")
+    result.assert_outcomes(passed=1)
+    # All reported durations must be well under one second (not epoch-scale).
+    for line in result.outlines:
+        m = re.match(r"^\s*([\d.]+)s\b", line)
+        if m:
+            assert float(m.group(1)) < 60.0, f"Epoch-scale duration detected: {line!r}"  # noqa: PLR2004
+
+
 # ---------------------------------------------------------------------------
 # asyncio.timeout integration inside a sync context manager (Python 3.11+)
 # ---------------------------------------------------------------------------
@@ -110,3 +137,108 @@ async def test_sync_timeout_not_raised_when_sleep_within_deadline():
     with SleepFake():
         async with asyncio.timeout(10):  # type: ignore[attr-defined]
             await asyncio.sleep(2)  # completes well within the 10 s deadline
+
+
+# ---------------------------------------------------------------------------
+# Fixture-based sync tests
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_sync_sleep(sleepfake: SleepFake) -> None:
+    """The ``sleepfake`` fixture patches time.sleep correctly."""
+    assert sleepfake.frozen_factory is not None
+    start = time.time()
+    time.sleep(SLEEP_DURATION)
+    end = time.time()
+    assert end - start >= SLEEP_DURATION
+
+
+def test_fixture_sync_multiple_sleeps(sleepfake: SleepFake) -> None:  # noqa: ARG001
+    """Sequential sleeps accumulate through the fixture."""
+    t0 = time.time()
+    time.sleep(2)
+    t1 = time.time()
+    time.sleep(3)
+    t2 = time.time()
+    assert t1 - t0 >= 2  # noqa: PLR2004
+    assert t2 - t0 >= 5  # noqa: PLR2004
+
+
+# ---------------------------------------------------------------------------
+# @pytest.mark.sleepfake — marker auto-applies SleepFake (pytester)
+# ---------------------------------------------------------------------------
+
+
+def test_marker_applies_sleepfake(pytester: pytest.Pytester) -> None:
+    """@pytest.mark.sleepfake should auto-patch time.sleep without a fixture."""
+    pytester.makepyfile("""
+        import time
+        import pytest
+
+        @pytest.mark.sleepfake
+        def test_marked():
+            start = time.time()
+            time.sleep(100)
+            end = time.time()
+            assert end - start >= 100
+    """)
+    result = pytester.runpytest_subprocess("-vvv")
+    result.assert_outcomes(passed=1)
+
+
+def test_marker_async_applies_sleepfake(pytester: pytest.Pytester) -> None:
+    """@pytest.mark.sleepfake should auto-patch asyncio.sleep for async tests."""
+    pytester.makepyfile("""
+        import asyncio
+        import pytest
+
+        @pytest.mark.sleepfake
+        @pytest.mark.asyncio
+        async def test_marked_async():
+            start = asyncio.get_running_loop().time()
+            await asyncio.sleep(100)
+            end = asyncio.get_running_loop().time()
+            assert end - start >= 100
+    """)
+    pytester.makeconftest("""
+        import pytest
+        pytest_plugins = ["pytest_asyncio"]
+    """)
+    result = pytester.runpytest_subprocess("-vvv", "-p", "pytest_asyncio")
+    result.assert_outcomes(passed=1)
+
+
+def test_marker_skipped_when_fixture_requested(pytester: pytest.Pytester) -> None:
+    """Marker should not double-patch when the sleepfake fixture is also used."""
+    pytester.makepyfile("""
+        import time
+        import pytest
+
+        @pytest.mark.sleepfake
+        def test_marker_plus_fixture(sleepfake):
+            start = time.time()
+            time.sleep(50)
+            end = time.time()
+            assert end - start >= 50
+    """)
+    result = pytester.runpytest_subprocess("-vvv")
+    result.assert_outcomes(passed=1)
+
+
+# ---------------------------------------------------------------------------
+# pytest-timeout integration — real-time watchdog must not be affected
+# ---------------------------------------------------------------------------
+
+
+def test_pytest_timeout_not_affected_by_frozen_time(pytester: pytest.Pytester) -> None:
+    """pytest-timeout uses real time; a 100 s fake sleep must not trigger a 5 s timeout."""
+    pytester.makepyfile("""
+        import time
+        import pytest
+
+        @pytest.mark.timeout(5)
+        def test_long_fake_sleep(sleepfake):
+            time.sleep(100)
+    """)
+    result = pytester.runpytest_subprocess("-vvv")
+    result.assert_outcomes(passed=1)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -328,13 +328,19 @@ def test_cli_flag_async_test(pytester: pytest.Pytester) -> None:
     """``--sleepfake`` CLI flag must also patch async tests."""
     pytester.makepyfile("""
         import asyncio
+        import pytest
 
+        @pytest.mark.asyncio
         async def test_async_no_fixture():
             start = asyncio.get_running_loop().time()
             await asyncio.sleep(100)
             assert asyncio.get_running_loop().time() - start >= 100
     """)
-    result = pytester.runpytest_subprocess("-vvv", "--sleepfake")
+    pytester.makeconftest("""
+        import pytest
+        pytest_plugins = ["pytest_asyncio"]
+    """)
+    result = pytester.runpytest_subprocess("-vvv", "--sleepfake", "-p", "pytest_asyncio")
     result.assert_outcomes(passed=1)
 
 
@@ -346,11 +352,17 @@ def test_autouse_ini_async_test(pytester: pytest.Pytester) -> None:
     """)
     pytester.makepyfile("""
         import asyncio
+        import pytest
 
+        @pytest.mark.asyncio
         async def test_async_no_fixture():
             start = asyncio.get_running_loop().time()
             await asyncio.sleep(100)
             assert asyncio.get_running_loop().time() - start >= 100
     """)
-    result = pytester.runpytest_subprocess("-vvv")
+    pytester.makeconftest("""
+        import pytest
+        pytest_plugins = ["pytest_asyncio"]
+    """)
+    result = pytester.runpytest_subprocess("-vvv", "-p", "pytest_asyncio")
     result.assert_outcomes(passed=1)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -242,3 +242,115 @@ def test_pytest_timeout_not_affected_by_frozen_time(pytester: pytest.Pytester) -
     """)
     result = pytester.runpytest_subprocess("-vvv")
     result.assert_outcomes(passed=1)
+
+
+# ---------------------------------------------------------------------------
+# sleepfake_autouse ini option
+# ---------------------------------------------------------------------------
+
+
+def test_autouse_ini_applies_sleepfake_globally(pytester: pytest.Pytester) -> None:
+    """sleepfake_autouse = true must patch every test without any fixture or marker."""
+    pytester.makeini("""
+        [pytest]
+        sleepfake_autouse = true
+    """)
+    pytester.makepyfile("""
+        import time
+
+        def test_no_fixture():
+            start = time.time()
+            time.sleep(100)
+            assert time.time() - start >= 100
+
+        def test_also_no_fixture():
+            start = time.time()
+            time.sleep(50)
+            assert time.time() - start >= 50
+    """)
+    result = pytester.runpytest_subprocess("-vvv")
+    result.assert_outcomes(passed=2)
+
+
+def test_autouse_ini_no_double_patch_with_fixture(pytester: pytest.Pytester) -> None:
+    """When autouse is on and the fixture is also requested, only one SleepFake is active."""
+    pytester.makeini("""
+        [pytest]
+        sleepfake_autouse = true
+    """)
+    pytester.makepyfile("""
+        import time
+
+        def test_with_fixture(sleepfake):
+            start = time.time()
+            time.sleep(10)
+            assert time.time() - start >= 10
+    """)
+    result = pytester.runpytest_subprocess("-vvv")
+    result.assert_outcomes(passed=1)
+
+
+def test_autouse_ini_no_double_patch_with_marker(pytester: pytest.Pytester) -> None:
+    """When autouse is on and a test also has the marker, only one SleepFake is active."""
+    pytester.makeini("""
+        [pytest]
+        sleepfake_autouse = true
+    """)
+    pytester.makepyfile("""
+        import time
+        import pytest
+
+        @pytest.mark.sleepfake
+        def test_marker_plus_autouse():
+            start = time.time()
+            time.sleep(10)
+            assert time.time() - start >= 10
+    """)
+    result = pytester.runpytest_subprocess("-vvv")
+    result.assert_outcomes(passed=1)
+
+
+def test_cli_flag_applies_sleepfake_globally(pytester: pytest.Pytester) -> None:
+    """``--sleepfake`` CLI flag must patch every test, same as sleepfake_autouse = true."""
+    pytester.makepyfile("""
+        import time
+
+        def test_no_fixture():
+            start = time.time()
+            time.sleep(100)
+            assert time.time() - start >= 100
+    """)
+    result = pytester.runpytest_subprocess("-vvv", "--sleepfake")
+    result.assert_outcomes(passed=1)
+
+
+def test_cli_flag_async_test(pytester: pytest.Pytester) -> None:
+    """``--sleepfake`` CLI flag must also patch async tests."""
+    pytester.makepyfile("""
+        import asyncio
+
+        async def test_async_no_fixture():
+            start = asyncio.get_running_loop().time()
+            await asyncio.sleep(100)
+            assert asyncio.get_running_loop().time() - start >= 100
+    """)
+    result = pytester.runpytest_subprocess("-vvv", "--sleepfake")
+    result.assert_outcomes(passed=1)
+
+
+def test_autouse_ini_async_test(pytester: pytest.Pytester) -> None:
+    """sleepfake_autouse = true must also patch async tests."""
+    pytester.makeini("""
+        [pytest]
+        sleepfake_autouse = true
+    """)
+    pytester.makepyfile("""
+        import asyncio
+
+        async def test_async_no_fixture():
+            start = asyncio.get_running_loop().time()
+            await asyncio.sleep(100)
+            assert asyncio.get_running_loop().time() - start >= 100
+    """)
+    result = pytester.runpytest_subprocess("-vvv")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION

## Summary

Adds three new ways to activate `SleepFake` in a test suite without wrapping every test in a context manager:

| Mechanism | How to use |
|---|---|
| `asleepfake` async fixture | `async def test_foo(asleepfake): ...` |
| `@pytest.mark.sleepfake` marker | marker on any sync or async test |
| Global autouse — ini | `sleepfake_autouse = true` in `pyproject.toml` |
| Global autouse — CLI flag | `pytest --sleepfake` |

All four mechanisms share the same double-patch guard: if a test already has `sleepfake` / `asleepfake` requested as a fixture, the marker and autouse hooks skip it.

---

## Changes

### `src/sleepfake/plugin.py`

- **`asleepfake` fixture** — async context-manager fixture that yi
## Summary

Adds three new ways to activate `SleepFake` in a test suite without wrapping every test in a context manager:

| Mechanism | How to use |
|---|---|
| `asleepfake` async fixture | `async def test_foo(asleepfake): ...` |
| `@pytest.mark.sleepfake` marker | marker on any sync or async test |
| Global autouse — ini | `sleepfake_autouse = true` in `pyproject.toml` |
| Global autouse — CLI flag | `pytest --sleepfake` |

All four mechanisms share the same double-patch guard: if a test already has `sleepfake` / `asleepfake` requested as a fixture, the marker and autouse hooks skip it.

---

## Changes

### `src/sleepfake/plugin.py`

- **`asleepfake` fixture** — async context-manager fixture that yields a `SleepFake` instance (mirrors the existing `sleepfake` sync fixture).
- **`@pytest.mark.sleepfake`** — registered marker; handled via module-level `pytest_runtest_setup` / `pytest_runtest_teardown` hooks (`tryfirst=True`). The instance is stored on the item with a private attribute so teardown is safe even if setup raised.
- **`pytest_addoption`** — adds `sleepfake_autouse` ini option (bool, default `false`) and `--sleepfake` CLI flag.
- **`_autouse_enabled(config)`** — helper that checks both the ini option and the CLI flag.
- **`pytest_configure`** — registers the marker; conditionally registers `_AutouseSleepFakePlugin` when autouse is enabled.
- **`_AutouseSleepFakePlugin`** — hook-based (not fixture-based, to avoid async-fixture-on-sync-test failures in strict asyncio mode). Skips tests that already have the fixture or marker active.

### `src/sleepfake/__init__.py`

- Added a `Note:` section to the class docstring explaining the global mock scope limitation (`from time import sleep` bypasses the mock because it binds to the original function at import time).

### `tests/test_sync.py`  (+244 lines)

New tests covering the plugin surface:

| Test | What it covers |
|---|---|
| `test_fixture_sync_sleep` | `sleepfake` fixture patches `time.sleep` |
| `test_fixture_sync_multiple_sleeps` | sequential sleeps accumulate on the frozen clock |
| `test_marker_applies_sleepfake` | sync test with `@pytest.mark.sleepfake`, no fixture |
| `test_marker_async_applies_sleepfake` | async test with the marker |
| `test_marker_skipped_when_fixture_requested` | marker does not double-patch when fixture present |
| `test_autouse_ini_applies_sleepfake_globally` | `sleepfake_autouse = true` patches two plain tests |
| `test_autouse_ini_no_double_patch_with_fixture` | autouse + fixture coexist without error |
| `test_autouse_ini_no_double_patch_with_marker` | autouse + marker coexist without error |
| `test_cli_flag_applies_sleepfake_globally` | `--sleepfake` patches a plain sync test |
| `test_cli_flag_async_test` | `--sleepfake` patches an async test |
| `test_autouse_ini_async_test` | `sleepfake_autouse = true` patches an async test |
| `test_pytest_timeout_not_affected_by_frozen_time` | `pytest-timeout` watchdog fires in real time |

### `tests/test_async.py`  (+62 lines)

New tests for the `asleepfake` async fixture:

| Test | What it covers |
|---|---|
| `test_async_fixture_sleep` | `asleepfake` fixture patches `asyncio.sleep` |
| `test_async_fixture_gather` | concurrent `asyncio.gather` with multiple sleeps |
| `test_async_fixture_cleanup` | processor task and queue are active during fixture, gone after |
| `test_fixture_async_sleep` | sync `sleepfake` fixture used inside an async test |
| `test_fixture_async_gather` | sync `sleepfake` + `asyncio.gather` |

### `README.md`

Full rewrite documenting all five usage modes with code examples:

1. Context manager (`with SleepFake()` / `async with SleepFake()`)
2. `sleepfake` pytest fixture
3. `asleepfake` async pytest fixture
4. `@pytest.mark.sleepfake` marker
5. Global autouse (Option A: ini, Option B: CLI flag, Option C: conftest autouse fixtures)

---

## Test results

```
43 passed  (previously 19)
ruff: all checks passed
mypy: no issues found
```
elds a `SleepFake` instance (mirrors the existing `sleepfake` sync fixture).
- **`@pytest.mark.sleepfake`** — registered marker; handled via module-level `pytest_runtest_setup` / `pytest_runtest_teardown` hooks (`tryfirst=True`). The instance is stored on the item with a private attribute so teardown is safe even if setup raised.
- **`pytest_addoption`** — adds `sleepfake_autouse` ini option (bool, default `false`) and `--sleepfake` CLI flag.
- **`_autouse_enabled(config)`** — helper that checks both the ini option and the CLI flag.
- **`pytest_configure`** — registers the marker; conditionally registers `_AutouseSleepFakePlugin` when autouse is enabled.
- **`_AutouseSleepFakePlugin`** — hook-based (not fixture-based, to avoid async-fixture-on-sync-test failures in strict asyncio mode). Skips tests that already have the fixture or marker active.

### `src/sleepfake/__init__.py`

- Added a `Note:` section to the class docstring explaining the global mock scope limitation (`from time import sleep` bypasses the mock because it binds to the original function at import time).

### `tests/test_sync.py`  (+244 lines)

New tests covering the plugin surface:

| Test | What it covers |
|---|---|
| `test_fixture_sync_sleep` | `sleepfake` fixture patches `time.sleep` |
| `test_fixture_sync_multiple_sleeps` | sequential sleeps accumulate on the frozen clock |
| `test_marker_applies_sleepfake` | sync test with `@pytest.mark.sleepfake`, no fixture |
| `test_marker_async_applies_sleepfake` | async test with the marker |
| `test_marker_skipped_when_fixture_requested` | marker does not double-patch when fixture present |
| `test_autouse_ini_applies_sleepfake_globally` | `sleepfake_autouse = true` patches two plain tests |
| `test_autouse_ini_no_double_patch_with_fixture` | autouse + fixture coexist without error |
| `test_autouse_ini_no_double_patch_with_marker` | autouse + marker coexist without error |
| `test_cli_flag_applies_sleepfake_globally` | `--sleepfake` patches a plain sync test |
| `test_cli_flag_async_test` | `--sleepfake` patches an async test |
| `test_autouse_ini_async_test` | `sleepfake_autouse = true` patches an async test |
| `test_pytest_timeout_not_affected_by_frozen_time` | `pytest-timeout` watchdog fires in real time |

### `tests/test_async.py`  (+62 lines)

New tests for the `asleepfake` async fixture:

| Test | What it covers |
|---|---|
| `test_async_fixture_sleep` | `asleepfake` fixture patches `asyncio.sleep` |
| `test_async_fixture_gather` | concurrent `asyncio.gather` with multiple sleeps |
| `test_async_fixture_cleanup` | processor task and queue are active during fixture, gone after |
| `test_fixture_async_sleep` | sync `sleepfake` fixture used inside an async test |
| `test_fixture_async_gather` | sync `sleepfake` + `asyncio.gather` |

### `README.md`

Full rewrite documenting all five usage modes with code examples:

1. Context manager (`with SleepFake()` / `async with SleepFake()`)
2. `sleepfake` pytest fixture
3. `asleepfake` async pytest fixture
4. `@pytest.mark.sleepfake` marker
5. Global autouse (Option A: ini, Option B: CLI flag, Option C: conftest autouse fixtures)

---

## Test results

```
43 passed  (previously 19)
ruff: all checks passed
mypy: no issues found
```

## Summary

Adds three new ways to activate `SleepFake` in a test suite without wrapping every test in a context manager:

| Mechanism | How to use |
|---|---|
| `asleepfake` async fixture | `async def test_foo(asleepfake): ...` |
| `@pytest.mark.sleepfake` marker | marker on any sync or async test |
| Global autouse — ini | `sleepfake_autouse = true` in `pyproject.toml` |
| Global autouse — CLI flag | `pytest --sleepfake` |

All four mechanisms share the same double-patch guard: if a test already has `sleepfake` / `asleepfake` requested as a fixture, the marker and autouse hooks skip it.

---

## Changes

### `src/sleepfake/plugin.py`

- **`asleepfake` fixture** — async context-manager fixture that yields a `SleepFake` instance (mirrors the existing `sleepfake` sync fixture).
- **`@pytest.mark.sleepfake`** — registered marker; handled via module-level `pytest_runtest_setup` / `pytest_runtest_teardown` hooks (`tryfirst=True`). The instance is stored on the item with a private attribute so teardown is safe even if setup raised.
- **`pytest_addoption`** — adds `sleepfake_autouse` ini option (bool, default `false`) and `--sleepfake` CLI flag.
- **`_autouse_enabled(config)`** — helper that checks both the ini option and the CLI flag.
- **`pytest_configure`** — registers the marker; conditionally registers `_AutouseSleepFakePlugin` when autouse is enabled.
- **`_AutouseSleepFakePlugin`** — hook-based (not fixture-based, to avoid async-fixture-on-sync-test failures in strict asyncio mode). Skips tests that already have the fixture or marker active.

### `src/sleepfake/__init__.py`

- Added a `Note:` section to the class docstring explaining the global mock scope limitation (`from time import sleep` bypasses the mock because it binds to the original function at import time).

### `tests/test_sync.py`  (+244 lines)

New tests covering the plugin surface:

| Test | What it covers |
|---|---|
| `test_fixture_sync_sleep` | `sleepfake` fixture patches `time.sleep` |
| `test_fixture_sync_multiple_sleeps` | sequential sleeps accumulate on the frozen clock |
| `test_marker_applies_sleepfake` | sync test with `@pytest.mark.sleepfake`, no fixture |
| `test_marker_async_applies_sleepfake` | async test with the marker |
| `test_marker_skipped_when_fixture_requested` | marker does not double-patch when fixture present |
| `test_autouse_ini_applies_sleepfake_globally` | `sleepfake_autouse = true` patches two plain tests |
| `test_autouse_ini_no_double_patch_with_fixture` | autouse + fixture coexist without error |
| `test_autouse_ini_no_double_patch_with_marker` | autouse + marker coexist without error |
| `test_cli_flag_applies_sleepfake_globally` | `--sleepfake` patches a plain sync test |
| `test_cli_flag_async_test` | `--sleepfake` patches an async test |
| `test_autouse_ini_async_test` | `sleepfake_autouse = true` patches an async test |
| `test_pytest_timeout_not_affected_by_frozen_time` | `pytest-timeout` watchdog fires in real time |

### `tests/test_async.py`  (+62 lines)

New tests for the `asleepfake` async fixture:

| Test | What it covers |
|---|---|
| `test_async_fixture_sleep` | `asleepfake` fixture patches `asyncio.sleep` |
| `test_async_fixture_gather` | concurrent `asyncio.gather` with multiple sleeps |
| `test_async_fixture_cleanup` | processor task and queue are active during fixture, gone after |
| `test_fixture_async_sleep` | sync `sleepfake` fixture used inside an async test |
| `test_fixture_async_gather` | sync `sleepfake` + `asyncio.gather` |

### `README.md`

Full rewrite documenting all five usage modes with code examples:

1. Context manager (`with SleepFake()` / `async with SleepFake()`)
2. `sleepfake` pytest fixture
3. `asleepfake` async pytest fixture
4. `@pytest.mark.sleepfake` marker
5. Global autouse (Option A: ini, Option B: CLI flag, Option C: conftest autouse fixtures)

---

## Test results

```
43 passed  (previously 19)
ruff: all checks passed
mypy: no issues found
```
