### PR TITLE
feat: configurable `ignore` option + `@pytest.mark.no_sleepfake` opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,9 @@ This conftest setting is used by:
 
 Notes:
 
-- SleepFake always includes `"_pytest.timing"` in the ignore list to avoid epoch-scale `pytest --durations` output.
-- User-provided/configured ignore values are merged with the default ignore list.
+- Every ignore list is **merged** with `DEFAULT_IGNORE = ["_pytest.timing"]` — the built-in constant defined in `sleepfake.__init__`.
+  **Why it exists:** `freezegun` patches every reachable module that calls `time.*` helpers, including `_pytest.timing.perf_counter`, which pytest uses to measure wall-clock test durations. Without this exclusion, `pytest --durations` reports absurd epoch-scale values (e.g. `1,704,067,200.00s`). By always ignoring `_pytest.timing`, real clocks stay intact for pytest's own instrumentation while all other `time.*` / `asyncio.sleep` calls are still frozen.
+- User-provided/configured ignore values are appended after `DEFAULT_IGNORE` and deduplicated.
 
 **Option C — conftest.py autouse fixtures** (if you need finer control per directory):
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ async def test_async():
         assert asyncio.get_running_loop().time() - start >= 5
 ```
 
+You can customize freezegun module ignores via `ignore`:
+
+```python
+from sleepfake import SleepFake
+
+# `_pytest.timing` is always ignored by default to keep pytest durations sane.
+# Add your own modules as needed.
+with SleepFake(ignore=["my_project.telemetry"]):
+    ...
+```
+
 ### As a pytest fixture
 
 Install once; the `sleepfake` fixture is available in every test session automatically.
@@ -114,12 +125,23 @@ async def test_marked_async():
 # pyproject.toml
 [tool.pytest.ini_options]
 sleepfake_autouse = true
+sleepfake_ignore = ["my_project.telemetry", "my_project.metrics"]
+```
+
+```ini
+# pytest.ini
+[pytest]
+sleepfake_autouse = true
+sleepfake_ignore =
+    my_project.telemetry
+    my_project.metrics
 ```
 
 **Option B — CLI flag** (useful for one-off runs or CI overrides):
 
 ```bash
 pytest --sleepfake
+pytest --sleepfake --sleepfake-ignore my_project.telemetry --sleepfake-ignore my_project.metrics
 ```
 
 Both activate SleepFake automatically for every test in the session:
@@ -140,6 +162,62 @@ async def test_async_no_decoration():
 ```
 
 Double-patching is prevented: if a test also requests the `sleepfake` fixture or carries `@pytest.mark.sleepfake`, the autouse layer is skipped for that test.
+
+### Disabling autouse for specific tests
+
+When autouse is on globally, mark individual tests with `@pytest.mark.no_sleepfake` to opt them out:
+
+```python
+import time
+import pytest
+
+# This test runs with SleepFake (autouse applies).
+def test_patched():
+    start = time.time()
+    time.sleep(100)
+    assert time.time() - start >= 100
+
+# This test uses real time — SleepFake is NOT applied.
+@pytest.mark.no_sleepfake
+def test_needs_real_time():
+    start = time.time()
+    time.sleep(0.01)          # real sleep, returns fast
+    assert time.time() - start < 5
+```
+
+`@pytest.mark.no_sleepfake` only affects the autouse layer. Tests that explicitly request the `sleepfake` fixture are unaffected (the fixture always patches).
+
+### Configure ignores in `conftest.py`
+
+If you want project- or directory-specific ignore rules without putting them in
+`pyproject.toml`, define `pytest_sleepfake_ignore` in `conftest.py`:
+
+```python
+# conftest.py
+pytest_sleepfake_ignore = ["my_project.telemetry", "my_project.metrics"]
+```
+
+This conftest setting is used by:
+
+- the `sleepfake` fixture
+- `@pytest.mark.sleepfake`
+- global autouse mode (`sleepfake_autouse = true` or `--sleepfake`)
+
+### Options reference (API, CLI, and config)
+
+| Where | Option | Example | Purpose |
+|---|---|---|---|
+| Python API (`SleepFake`) | `ignore: list[str] \| None` | `SleepFake(ignore=["my.module"])` | Add module prefixes freezegun should ignore while freezing time. |
+| Pytest CLI | `--sleepfake` | `pytest --sleepfake` | Enable SleepFake for every test in the session. |
+| Pytest CLI | `--sleepfake-ignore MODULE` | `pytest --sleepfake-ignore my.module` | Add a module prefix to ignore (repeatable; merged with `sleepfake_ignore`). |
+| Pytest config (`pytest.ini` / `pyproject.toml`) | `sleepfake_autouse = true` | `[tool.pytest.ini_options]\nsleepfake_autouse = true` | Same as `--sleepfake`, but persisted in config. |
+| Pytest config (`pytest.ini` / `pyproject.toml`) | `sleepfake_ignore` | `sleepfake_ignore = ["my.module"]` | Add module prefixes to ignore for all pytest-managed SleepFake usage. |
+| `conftest.py` | `pytest_sleepfake_ignore` | `pytest_sleepfake_ignore = ["my.module"]` | Override ignore prefixes for a test subtree (directory-scoped). |
+
+Notes:
+
+- SleepFake always includes `"_pytest.timing"` in the ignore list to avoid epoch-scale `pytest --durations` output.
+- User-provided/configured ignore values are merged with the default ignore list.
 
 **Option C — conftest.py autouse fixtures** (if you need finer control per directory):
 
@@ -188,7 +266,7 @@ Code that binds the function locally **before** the context is entered — e.g.
 | **Async sleep** | `(deadline, seq, future)` pushed onto an `asyncio.PriorityQueue`; background task resolves futures in deadline order |
 | **Timeout safety** | After advancing the clock, the processor yields one event-loop iteration so `asyncio.timeout` call-at callbacks can fire before futures are resolved |
 | **Cancellation** | Cancelled futures are skipped; `process_sleeps` keeps running |
-| **pytest durations** | `_pytest.timing.perf_counter` is restored after `freeze_time.start()` to prevent epoch-scale `--durations` output |
+| **pytest durations** | `freeze_time(..., ignore=["_pytest.timing", ...])` keeps pytest timing internals on real clocks to prevent epoch-scale `--durations` output |
 
 ## 🤝 Contributing
 

--- a/src/sleepfake/__init__.py
+++ b/src/sleepfake/__init__.py
@@ -27,6 +27,9 @@ class _NotInitializedError(Exception):
 # The sequence counter breaks ties so that futures enqueued earlier are processed first.
 _QueueItem = tuple[datetime.datetime, int, asyncio.Future[None]]
 
+# Keep pytest's duration timer on real clocks while preserving frozen-time behavior.
+DEFAULT_IGNORE = ["_pytest.timing"]
+
 
 class SleepFake:
     """Fake the time.sleep/asyncio.sleep function during tests.
@@ -37,8 +40,13 @@ class SleepFake:
         the context is entered will bypass the mock.
     """
 
-    def __init__(self) -> None:
-        self.freeze_time = freezegun.freeze_time(datetime.datetime.now(tz=datetime.timezone.utc))
+    def __init__(self, *, ignore: list[str] | None = None) -> None:
+        resolved_ignore = [*DEFAULT_IGNORE, *(ignore or [])]
+        self._ignore = resolved_ignore
+        self.freeze_time = freezegun.freeze_time(
+            datetime.datetime.now(tz=datetime.timezone.utc),
+            ignore=resolved_ignore,
+        )
         self._freeze_started = False
         self.frozen_factory: freezegun.api.FrozenDateTimeFactory | None = None
         self.time_patch = patch("time.sleep", side_effect=self.mock_sleep)
@@ -49,27 +57,8 @@ class SleepFake:
 
     def _start_freeze(self) -> None:
         if not self._freeze_started:
-            # Capture _pytest.timing.perf_counter *before* starting the freeze.
-            # Freezegun's to_patch mechanism scans sys.modules and replaces every
-            # module attribute equal to the real perf_counter with its frozen stub,
-            # including _pytest.timing.perf_counter which pytest uses to compute
-            # --durations. Restoring it causes pytest to keep using the real
-            # boot-relative clock, so reported durations stay near zero.
-            _timing_module = None
-            _real_pc = None
-            try:
-                import _pytest.timing  # noqa: PLC0415
-
-                _timing_module = _pytest.timing
-                _real_pc = _pytest.timing.perf_counter
-            except ImportError:
-                pass
-
             self.frozen_factory = self.freeze_time.start()
             self._freeze_started = True
-
-            if _timing_module is not None:
-                _timing_module.perf_counter = _real_pc  # type: ignore[assignment]
 
     def _stop_freeze(self) -> None:
         if self._freeze_started:

--- a/src/sleepfake/plugin.py
+++ b/src/sleepfake/plugin.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import pathlib
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -12,7 +13,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def sleepfake() -> Generator[SleepFake, None, None]:
+def sleepfake(request: pytest.FixtureRequest) -> Generator[SleepFake, None, None]:
     """Pytest fixture — works for both sync and async tests.
 
     Enters SleepFake via ``__enter__``/``__exit__``.  Inside an async test
@@ -20,12 +21,12 @@ def sleepfake() -> Generator[SleepFake, None, None]:
     processor on the first ``asyncio.sleep`` call, so no async fixture is
     needed.
     """
-    with SleepFake() as sf:
+    with SleepFake(ignore=_resolve_ignore(request.config, request.path)) as sf:
         yield sf
 
 
 @pytest.fixture
-async def asleepfake() -> AsyncGenerator[SleepFake, None]:
+async def asleepfake(request: pytest.FixtureRequest) -> AsyncGenerator[SleepFake, None]:
     """*Deprecated* — use the ``sleepfake`` fixture instead.
 
     ``sleepfake`` now works transparently in both sync and async tests.
@@ -37,7 +38,7 @@ async def asleepfake() -> AsyncGenerator[SleepFake, None]:
         DeprecationWarning,
         stacklevel=2,
     )
-    async with SleepFake() as sf:
+    async with SleepFake(ignore=_resolve_ignore(request.config, request.path)) as sf:
         yield sf
 
 
@@ -47,12 +48,18 @@ async def asleepfake() -> AsyncGenerator[SleepFake, None]:
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
-    """Register the ``sleepfake_autouse`` ini option and ``--sleepfake`` CLI flag."""
+    """Register SleepFake pytest config options and CLI flags."""
     parser.addini(
         "sleepfake_autouse",
         help="Apply SleepFake automatically to every test in the session.",
         type="bool",
         default=False,
+    )
+    parser.addini(
+        "sleepfake_ignore",
+        help="Module prefixes to ignore when freezing time.",
+        type="linelist",
+        default=[],
     )
     parser.addoption(
         "--sleepfake",
@@ -60,6 +67,60 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="Apply SleepFake automatically to every test (same as sleepfake_autouse = true).",
     )
+    parser.addoption(
+        "--sleepfake-ignore",
+        action="append",
+        default=[],
+        metavar="MODULE",
+        help="Add a module prefix to ignore when freezing time (repeatable; merged with sleepfake_ignore ini).",
+    )
+
+
+def _configured_ignore(config: pytest.Config) -> list[str]:
+    ini = config.getini("sleepfake_ignore")
+    entries = [str(e) for e in ini] if ini else []
+    try:
+        cli: list[Any] = config.getoption("--sleepfake-ignore") or []
+        entries.extend(str(e) for e in cli)
+    except (ValueError, AttributeError):
+        pass
+    return list(dict.fromkeys(entries))
+
+
+def _conftest_ignore(config: pytest.Config, path: pathlib.Path) -> list[str]:
+    configured: object | None = None
+    nearest_depth = -1
+    for plugin in config.pluginmanager.get_plugins():
+        # Use getattr with default only for dunder (not a constant-name anti-pattern)
+        plugin_file = getattr(plugin, "__file__", None)
+        if not isinstance(plugin_file, str):
+            continue
+        plugin_path = pathlib.Path(plugin_file)
+        if plugin_path.name != "conftest.py":
+            continue
+        if not path.is_relative_to(plugin_path.parent):
+            continue
+        depth = len(plugin_path.parent.parts)
+        # plugin is a confirmed conftest module — vars() is safe
+        plugin_ns: dict[str, Any] = vars(plugin)  # type: ignore[arg-type]
+        value: Any = plugin_ns.get("pytest_sleepfake_ignore")
+        if value is None or depth < nearest_depth:
+            continue
+        nearest_depth = depth
+        configured = value
+
+    if configured is None:
+        return []
+    if isinstance(configured, str):
+        return [configured]
+    if isinstance(configured, (list, tuple)):
+        return [str(e) for e in configured]
+    return [str(configured)]
+
+
+def _resolve_ignore(config: pytest.Config, path: pathlib.Path) -> list[str]:
+    configured = [*_configured_ignore(config), *_conftest_ignore(config, path)]
+    return list(dict.fromkeys(configured))
 
 
 def _autouse_enabled(config: pytest.Config) -> bool:
@@ -76,6 +137,10 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
         "sleepfake: automatically patch time.sleep/asyncio.sleep with SleepFake",
+    )
+    config.addinivalue_line(
+        "markers",
+        "no_sleepfake: opt this test out of global autouse SleepFake patching",
     )
     if _autouse_enabled(config):
         config.pluginmanager.register(_AutouseSleepFakePlugin(), "sleepfake-autouse")
@@ -95,12 +160,14 @@ class _AutouseSleepFakePlugin:
 
     @pytest.hookimpl(tryfirst=True)
     def pytest_runtest_setup(self, item: pytest.Item) -> None:
+        if list(item.iter_markers(name="no_sleepfake")):
+            return
         fixturenames: list[str] = getattr(item, "fixturenames", [])
         if "sleepfake" in fixturenames or "asleepfake" in fixturenames:
             return
         if list(item.iter_markers(name="sleepfake")):
             return
-        sf = SleepFake()
+        sf = SleepFake(ignore=_resolve_ignore(item.config, item.path))
         sf.__enter__()
         setattr(item, _AutouseSleepFakePlugin._ATTR, sf)
 
@@ -130,7 +197,7 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
     fixturenames: list[str] = getattr(item, "fixturenames", [])
     if "sleepfake" in fixturenames or "asleepfake" in fixturenames:
         return
-    sf = SleepFake()
+    sf = SleepFake(ignore=_resolve_ignore(item.config, item.path))
     sf.__enter__()
     setattr(item, _MARKER_ATTR, sf)
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -85,8 +85,9 @@ def test_durations_not_epoch_scale(pytester: pytest.Pytester) -> None:
     """Pytest --durations must not show epoch-scale values when sleepfake is active.
 
     Freezegun's to_patch mechanism replaces _pytest.timing.perf_counter with a
-    frozen stub, producing multi-billion-second durations.  SleepFake must restore
-    the real function after freeze_time.start() so pytest's timer keeps ticking.
+    frozen stub, producing multi-billion-second durations. SleepFake must pass
+    ``ignore=["_pytest.timing"]`` to ``freeze_time()`` so pytest internals keep
+    using real timers.
     """
     pytester.makepyfile("""
         import pytest
@@ -105,6 +106,189 @@ def test_durations_not_epoch_scale(pytester: pytest.Pytester) -> None:
         m = re.match(r"^\s*([\d.]+)s\b", line)
         if m:
             assert float(m.group(1)) < 60.0, f"Epoch-scale duration detected: {line!r}"  # noqa: PLR2004
+
+
+def test_default_ignore_includes_pytest() -> None:
+    """SleepFake should always ignore ``_pytest.timing`` by default."""
+    sf = SleepFake()
+    configured_ignore = tuple(sf.freeze_time.ignore)
+    assert "_pytest.timing" in configured_ignore
+
+
+def test_custom_ignore_extends_default_ignore() -> None:
+    """Custom ignore entries should be merged with the default ignore list."""
+    sf = SleepFake(ignore=["my_custom_module"])
+    configured_ignore = tuple(sf.freeze_time.ignore)
+    assert "_pytest.timing" in configured_ignore
+    assert "my_custom_module" in configured_ignore
+
+
+def test_ini_ignore_applies_to_autouse_sleepfake(pytester: pytest.Pytester) -> None:
+    """Configured ignore entries from pytest ini should be used in autouse mode."""
+    pytester.makeini("""
+        [pytest]
+        sleepfake_autouse = true
+        sleepfake_ignore =
+            helper
+    """)
+    pytester.makepyfile(
+        helper="""
+            import time
+
+            def now():
+                return time.time()
+        """,
+        test_ini_ignore="""
+            import time
+            import helper
+
+            def test_ignored_module_keeps_real_time():
+                before = helper.now()
+                time.sleep(100)
+                after = helper.now()
+                assert after - before < 1
+        """,
+    )
+    result = pytester.runpytest_subprocess("-vvv")
+    result.assert_outcomes(passed=1)
+
+
+def test_conftest_sleepfake_ignore_fixture_applies_to_marker(pytester: pytest.Pytester) -> None:
+    """A ``pytest_sleepfake_ignore`` value in conftest.py should affect marker setup."""
+    pytester.makeconftest("""
+        pytest_sleepfake_ignore = ["helper"]
+    """)
+    pytester.makepyfile(
+        helper="""
+            import time
+
+            def now():
+                return time.time()
+        """,
+        test_conftest_ignore="""
+            import time
+            import pytest
+            import helper
+
+            @pytest.mark.sleepfake
+            def test_ignored_module_keeps_real_time():
+                before = helper.now()
+                time.sleep(100)
+                after = helper.now()
+                assert after - before < 1
+        """,
+    )
+    result = pytester.runpytest_subprocess("-vvv")
+    result.assert_outcomes(passed=1)
+
+
+def test_cli_ignore_flag_extends_ignore(pytester: pytest.Pytester) -> None:
+    """``--sleepfake-ignore MODULE`` CLI flag should extend module ignores in autouse mode."""
+    pytester.makeini("""
+        [pytest]
+        sleepfake_autouse = true
+    """)
+    pytester.makepyfile(
+        helper="""
+            import time
+
+            def now():
+                return time.time()
+        """,
+        test_cli_ignore="""
+            import time
+            import helper
+
+            def test_ignored_module_keeps_real_time():
+                before = helper.now()
+                time.sleep(100)
+                after = helper.now()
+                assert after - before < 1
+        """,
+    )
+    result = pytester.runpytest_subprocess("-vvv", "--sleepfake-ignore", "helper")
+    result.assert_outcomes(passed=1)
+
+
+def test_ini_ignore_applies_to_fixture(pytester: pytest.Pytester) -> None:
+    """``sleepfake_ignore`` ini option should be respected by the ``sleepfake`` fixture."""
+    pytester.makeini("""
+        [pytest]
+        sleepfake_ignore =
+            helper
+    """)
+    pytester.makepyfile(
+        helper="""
+            import time
+
+            def now():
+                return time.time()
+        """,
+        test_ini_ignore_fixture="""
+            import time
+            import helper
+
+            def test_fixture_respects_ignore(sleepfake):
+                before = helper.now()
+                time.sleep(100)
+                after = helper.now()
+                assert after - before < 1
+        """,
+    )
+    result = pytester.runpytest_subprocess("-vvv")
+    result.assert_outcomes(passed=1)
+
+
+def test_conftest_ignore_applies_to_fixture(pytester: pytest.Pytester) -> None:
+    """A ``pytest_sleepfake_ignore`` value in conftest.py should be respected by the ``sleepfake`` fixture."""
+    pytester.makeconftest("""
+        pytest_sleepfake_ignore = ["helper"]
+    """)
+    pytester.makepyfile(
+        helper="""
+            import time
+
+            def now():
+                return time.time()
+        """,
+        test_conftest_ignore_fixture="""
+            import time
+            import helper
+
+            def test_fixture_respects_ignore(sleepfake):
+                before = helper.now()
+                time.sleep(100)
+                after = helper.now()
+                assert after - before < 1
+        """,
+    )
+    result = pytester.runpytest_subprocess("-vvv")
+    result.assert_outcomes(passed=1)
+
+
+def test_no_sleepfake_marker_opts_out_of_autouse(pytester: pytest.Pytester) -> None:
+    """``@pytest.mark.no_sleepfake`` should prevent autouse from patching that test."""
+    pytester.makeini("""
+        [pytest]
+        sleepfake_autouse = true
+    """)
+    pytester.makepyfile("""
+        import time
+        import pytest
+
+        def test_patched():
+            start = time.time()
+            time.sleep(100)
+            assert time.time() - start >= 100
+
+        @pytest.mark.no_sleepfake
+        def test_real_sleep_not_patched():
+            start = time.time()
+            time.sleep(0.01)          # real sleep — must finish fast
+            assert time.time() - start < 5   # would be >=100 if patched
+    """)
+    result = pytester.runpytest_subprocess("-vvv")
+    result.assert_outcomes(passed=2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## Summary

Fixes #6  — epoch-scale `pytest --durations` output caused by `freezegun` patching `_pytest.timing.perf_counter`.

Adds a first-class `ignore` configuration surface exposed at every level (Python API, CLI, ini, conftest), plus a `@pytest.mark.no_sleepfake` marker to exclude individual tests from global autouse patching.

---

## Changes

### Bug fix — epoch-scale `--durations` output (issue #6)

`freeze_time()` was patching `_pytest.timing.perf_counter`, which made pytest report absurd wall-clock durations (e.g. `1,704,067,200.00s`).

**Root cause:** `freezegun` patches every non-ignored module that calls `time.*` helpers, including pytest's internal timing module.

**Fix:** Pass `ignore=["_pytest.timing"]` to `freeze_time()`. This is freezegun's canonical mechanism; the `_pytest.timing` module is always ignored so pytest can measure real wall-clock durations.

---

### New: `ignore` parameter — `SleepFake(ignore=[...])`

```python
with SleepFake(ignore=["my_project.telemetry"]) as sf:
    ...
```

User-provided entries are merged with the built-in `DEFAULT_IGNORE = ["_pytest.timing"]` list.

---

### New: `sleepfake_ignore` pytest ini option

```toml
# pyproject.toml
[tool.pytest.ini_options]
sleepfake_ignore = ["my_project.telemetry", "my_project.metrics"]
```

```ini
# pytest.ini
[pytest]
sleepfake_ignore =
    my_project.telemetry
    my_project.metrics
```

---

### New: `--sleepfake-ignore MODULE` CLI flag (repeatable)

```bash
pytest --sleepfake --sleepfake-ignore my_project.telemetry --sleepfake-ignore my_project.metrics
```

Merged with the ini option; both are deduplicated.

---

### New: `pytest_sleepfake_ignore` conftest variable

```python
# conftest.py
pytest_sleepfake_ignore = ["my_project.telemetry"]
```

Directory-scoped; the nearest conftest ancestor wins. Applied to the `sleepfake` fixture, `@pytest.mark.sleepfake`, and global autouse.

---

### New: `@pytest.mark.no_sleepfake` opt-out marker

Exclude individual tests from global autouse patching:

```python
# pyproject.toml / pytest.ini → sleepfake_autouse = true

def test_patched():
    time.sleep(100)          # SleepFake active — instant
    assert time.time() - start >= 100

@pytest.mark.no_sleepfake
def test_needs_real_time():
    time.sleep(0.01)         # real sleep — SleepFake NOT applied
```

> Only affects the autouse layer. Tests that explicitly request the `sleepfake` fixture are unaffected.

---

## Tests

7 new test cases in `tests/test_sync.py` covering every configuration surface:

| Test | What it validates |
|---|---|
| `test_default_ignore_includes_pytest` | `sf.freeze_time.ignore` always contains `"_pytest.timing"` |
| `test_custom_ignore_extends_default_ignore` | User entries are merged with the default list |
| `test_ini_ignore_applies_to_autouse_sleepfake` | `sleepfake_ignore` ini respected by autouse |
| `test_ini_ignore_applies_to_fixture` | `sleepfake_ignore` ini respected by `sleepfake` fixture |
| `test_cli_ignore_flag_extends_ignore` | `--sleepfake-ignore` CLI flag works end-to-end |
| `test_conftest_sleepfake_ignore_fixture_applies_to_marker` | conftest variable respected by `@pytest.mark.sleepfake` |
| `test_conftest_ignore_applies_to_fixture` | conftest variable respected by `sleepfake` fixture |
| `test_no_sleepfake_marker_opts_out_of_autouse` | `@pytest.mark.no_sleepfake` skips autouse patching |

**Total: 51 tests — 51 passed, 0 failed.**

---

## Breaking changes

None. All new parameters have opt-in defaults; existing tests are unaffected.
