### PR TITLE
feat: broad patching — cover `from time import sleep` module-level aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,22 @@ Notes:
 
 ## ⚠️ Scope limitation
 
-SleepFake patches `time.sleep` and `asyncio.sleep` by name via `unittest.mock.patch`.
-Code that binds the function locally **before** the context is entered (for example `from time import sleep` at module import time) bypasses the patch.
+SleepFake patches `time.sleep` and `asyncio.sleep` at three levels:
+
+1. **The source module** (`time.sleep` / `asyncio.sleep`) — via `unittest.mock.patch`.
+2. **Module-level aliases in `sys.modules`** — any attribute that points to the original
+   `time.sleep` or `asyncio.sleep` at context entry is patched too. This covers the common
+   `from time import sleep` pattern at the top of a module.
+
+The one case that **cannot** be covered is a **local variable** binding created inside a
+function body before the context is entered:
+
+```python
+def hard_to_patch():
+    _sleep = time.sleep   # local variable — not visible in sys.modules
+    with SleepFake():
+        _sleep(10)        # ⚠️ calls the real time.sleep; cannot be intercepted
+```
 
 ## 🧪 How it works
 
@@ -300,6 +314,7 @@ Code that binds the function locally **before** the context is entered (for exam
 |---|---|
 | **Sync sleep** | `frozen_factory.tick(delta)` advances frozen time immediately |
 | **Async sleep** | `(deadline, seq, future)` goes into an `asyncio.PriorityQueue`; a background task resolves futures in deadline order |
+| **Broad patching** | On context entry, `sys.modules` is scanned for module-level aliases of the originals (e.g. `from time import sleep`); all matched attributes are replaced and restored on exit |
 | **Timeout safety** | After advancing time, the processor yields one event-loop turn so timeout callbacks can fire before futures resolve |
 | **Cancellation** | Cancelled futures are skipped; the processor keeps running |
 | **pytest durations** | `freeze_time(..., ignore=["_pytest.timing", ...])` avoids breaking pytest internal wall-clock timing |

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Notes:
 
 ## ⚠️ Scope limitation
 
-SleepFake patches `time.sleep` and `asyncio.sleep` at three levels:
+SleepFake patches `time.sleep` and `asyncio.sleep` at two levels:
 
 1. **The source module** (`time.sleep` / `asyncio.sleep`) — via `unittest.mock.patch`.
 2. **Module-level aliases in `sys.modules`** — any attribute that points to the original

--- a/src/sleepfake/core.py
+++ b/src/sleepfake/core.py
@@ -4,6 +4,9 @@ import asyncio
 import contextlib
 import datetime
 import sys
+import time as _time_module
+import types
+import warnings
 from typing import Final
 from unittest.mock import patch
 
@@ -32,14 +35,22 @@ _QueueItem = tuple[datetime.datetime, int, asyncio.Future[None]]
 # during a test does not trigger a false ``session-timeout`` failure.
 DEFAULT_IGNORE: Final[list[str]] = ["_pytest.timing", "pytest_timeout"]
 
+# Captured at import time, before any mock patch can replace them.
+# Used by the broad-patch mechanism to locate module-level aliases.
+_ORIG_TIME_SLEEP: Final = _time_module.sleep
+_ORIG_ASYNCIO_SLEEP: Final = asyncio.sleep
+
 
 class SleepFake:
     """Fake the time.sleep/asyncio.sleep function during tests.
 
     Note:
-        Uses ``unittest.mock.patch("time.sleep")`` / ``patch("asyncio.sleep")``.
-        Code that binds the function locally (``from time import sleep``) before
-        the context is entered will bypass the mock.
+        In addition to ``unittest.mock.patch("time.sleep")`` / ``patch("asyncio.sleep")``,
+        :class:`SleepFake` scans ``sys.modules`` on context entry and replaces any
+        module-level aliases of the real functions (e.g. ``from time import sleep``).
+        The one case that cannot be covered is a **local variable** binding created
+        inside a function body before the context is entered — those are invisible to
+        ``sys.modules`` and will still call the real ``time.sleep``.
 
     Examples:
         Synchronous — clock jumps instantly, no real wall-clock delay:
@@ -95,6 +106,55 @@ class SleepFake:
         self.sleep_queue: asyncio.PriorityQueue[_QueueItem] | None = None
         self.sleep_processor: asyncio.Task[None] | None = None
         self._seq: int = 0  # tie-breaker for equal deadlines
+        self._alias_patches: list[tuple[types.ModuleType, str, object]] = []
+
+    def _patch_module_aliases(self) -> None:
+        """Scan ``sys.modules`` and patch any module-level aliases of the real sleep functions.
+
+        This covers code that ran ``from time import sleep`` (or
+        ``from asyncio import sleep``) before the :class:`SleepFake` context was
+        entered.  All such attributes in loaded modules are replaced with the
+        corresponding mock, and the originals are recorded for restoration in
+        :meth:`_unpatch_module_aliases`.
+        """
+        self._alias_patches = []
+        # Skip the modules that either already received the main patch or hold our
+        # own internal sentinel variables (_ORIG_TIME_SLEEP / _ORIG_ASYNCIO_SLEEP).
+        _self = sys.modules.get(__name__)
+        ignore = tuple(self._ignore)
+
+        for mod_name, mod in list(sys.modules.items()):
+            if not isinstance(mod, types.ModuleType):
+                continue
+            if mod is _time_module or mod is asyncio or mod is _self:
+                continue
+            # Mirror freezegun: honour the ignore list so that ignored modules
+            # also keep their real sleep references (e.g. _pytest.timing).
+            if mod_name.startswith(ignore):
+                continue
+            try:
+                mod_dict = mod.__dict__
+            except AttributeError:  # pragma: no cover
+                continue
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                for name, val in list(mod_dict.items()):
+                    if val is _ORIG_TIME_SLEEP:
+                        replacement: object = self.mock_sleep
+                    elif val is _ORIG_ASYNCIO_SLEEP:
+                        replacement = self.amock_sleep
+                    else:
+                        continue
+                    with contextlib.suppress(AttributeError, TypeError):
+                        setattr(mod, name, replacement)
+                        self._alias_patches.append((mod, name, val))
+
+    def _unpatch_module_aliases(self) -> None:
+        """Restore every module-level alias that was patched by :meth:`_patch_module_aliases`."""
+        for mod, name, original in reversed(self._alias_patches):
+            with contextlib.suppress(AttributeError, TypeError):
+                setattr(mod, name, original)
+        self._alias_patches = []
 
     def _start_freeze(self) -> None:
         if not self._freeze_started:
@@ -122,6 +182,7 @@ class SleepFake:
         self._start_freeze()
         self.time_patch.start()
         self.asyncio_patch.start()
+        self._patch_module_aliases()
         self.sleep_processor = None
         self._seq = 0
         return self
@@ -150,6 +211,7 @@ class SleepFake:
         Safe to call multiple times; subsequent calls are no-ops once the
         processor has already been stopped.
         """
+        self._unpatch_module_aliases()
         self.time_patch.stop()
         self.asyncio_patch.stop()
         self._stop_freeze()
@@ -178,6 +240,7 @@ class SleepFake:
             exc_val: The exception instance, or ``None``.
             exc_tb: The traceback, or ``None``.
         """
+        self._unpatch_module_aliases()
         self.time_patch.stop()
         self.asyncio_patch.stop()
         self._stop_freeze()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import types
 
 import pytest
 
@@ -420,3 +421,28 @@ async def test_process_sleeps_raises_when_queue_is_none() -> None:
     sf = SleepFake()
     with pytest.raises(_NotInitializedError):
         await sf.process_sleeps()
+
+
+# ---------------------------------------------------------------------------
+# Broad patching — asyncio.sleep module-level aliases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broad_patch_asyncio_sleep_module_alias() -> None:
+    """SleepFake patches module-level ``from asyncio import sleep`` aliases in sys.modules."""
+    original_sleep = asyncio.sleep  # capture before any context is active
+    fake_mod = types.ModuleType("_sleepfake_test_broad_async")
+    fake_mod.sleep = original_sleep  # type: ignore[attr-defined]  # simulates ``from asyncio import sleep``
+    sys.modules["_sleepfake_test_broad_async"] = fake_mod
+    try:
+        with SleepFake():
+            # The alias must have been replaced with a mock (not the original coroutine).
+            assert fake_mod.sleep is not original_sleep  # type: ignore[attr-defined]
+            start = asyncio.get_running_loop().time()
+            await fake_mod.sleep(5)  # type: ignore[attr-defined]
+            assert asyncio.get_running_loop().time() - start >= 5  # noqa: PLR2004
+        # After exit the alias is restored.
+        assert fake_mod.sleep is original_sleep  # type: ignore[attr-defined]
+    finally:
+        sys.modules.pop("_sleepfake_test_broad_async", None)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,6 +2,7 @@ import asyncio
 import re
 import sys
 import time
+import types
 
 import pytest
 
@@ -607,3 +608,50 @@ def test_mock_sleep_outside_context_raises() -> None:
     sf = SleepFake()
     with pytest.raises(RuntimeError, match="outside SleepFake context"):
         sf.mock_sleep(1)
+
+
+# ---------------------------------------------------------------------------
+# Broad patching — module-level aliases (``from time import sleep``)
+# ---------------------------------------------------------------------------
+
+
+def test_broad_patch_time_sleep_module_alias() -> None:
+    """SleepFake patches module-level ``from time import sleep`` aliases in sys.modules."""
+    original_sleep = time.sleep  # capture before any context is active
+    fake_mod = types.ModuleType("_sleepfake_test_broad_sync")
+    fake_mod.sleep = original_sleep  # type: ignore[attr-defined]  # simulates ``from time import sleep``
+    sys.modules["_sleepfake_test_broad_sync"] = fake_mod
+    try:
+        with SleepFake():
+            # The alias must have been replaced with a mock (not the original builtin).
+            assert fake_mod.sleep is not original_sleep  # type: ignore[attr-defined]
+            t0 = time.time()
+            fake_mod.sleep(10)  # type: ignore[attr-defined]
+            assert time.time() - t0 >= 10  # noqa: PLR2004
+        # After exit the alias is restored.
+        assert fake_mod.sleep is original_sleep  # type: ignore[attr-defined]
+    finally:
+        sys.modules.pop("_sleepfake_test_broad_sync", None)
+
+
+def test_broad_patch_restores_alias_on_exception() -> None:
+    """Module-level aliases are restored even when the context body raises."""
+    fake_mod = types.ModuleType("_sleepfake_test_broad_exc")
+    fake_mod.sleep = time.sleep  # type: ignore[attr-defined]
+    sys.modules["_sleepfake_test_broad_exc"] = fake_mod
+    try:
+        with pytest.raises(RuntimeError), SleepFake():
+            raise RuntimeError("boom")
+        assert fake_mod.sleep is time.sleep  # type: ignore[attr-defined]
+    finally:
+        sys.modules.pop("_sleepfake_test_broad_exc", None)
+
+
+def test_broad_patch_does_not_patch_local_variable() -> None:
+    """A local variable binding is NOT patched (not visible in sys.modules)."""
+    local_sleep = time.sleep  # bound before context entry — not patchable
+    with SleepFake():
+        # local_sleep still references the real function
+        assert local_sleep is time.sleep or local_sleep is not time.sleep  # always True
+        # Verify by checking it is not our mock_sleep
+        assert not hasattr(local_sleep, "_mock_name")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -649,9 +649,10 @@ def test_broad_patch_restores_alias_on_exception() -> None:
 
 def test_broad_patch_does_not_patch_local_variable() -> None:
     """A local variable binding is NOT patched (not visible in sys.modules)."""
+    original_sleep = time.sleep
     local_sleep = time.sleep  # bound before context entry — not patchable
     with SleepFake():
-        # local_sleep still references the real function
-        assert local_sleep is time.sleep or local_sleep is not time.sleep  # always True
-        # Verify by checking it is not our mock_sleep
-        assert not hasattr(local_sleep, "_mock_name")
+        # local_sleep still references the original real function
+        assert local_sleep is original_sleep
+        # But the global time.sleep has been patched inside the context
+        assert time.sleep is not original_sleep


### PR DESCRIPTION
## feat: broad patching — cover `from time import sleep` module-level aliases

### Problem

`SleepFake` used only `unittest.mock.patch("time.sleep")` / `patch("asyncio.sleep")`.
That replaces the name **in the source module only**.
Code that imports the function directly at module level is unaffected:

```python
# some_module.py
from time import sleep        # alias bound at import time

def do_work():
    sleep(30)                 # ← called the real time.sleep even inside SleepFake
```

### Solution

On `__enter__` / `__aenter__`, `SleepFake` now scans `sys.modules` and replaces every
module-level attribute whose identity matches the original `time.sleep` or `asyncio.sleep`
with the corresponding mock.  On exit the originals are restored in reverse order.

This mirrors the mechanism that [freezegun](https://github.com/spulec/freezegun/blob/master/freezegun/api.py)
uses for `datetime` / `time.time` aliases.

### What's covered

| Pattern | Covered? |
|---|---|
| `time.sleep(...)` | ✅ (existing `unittest.mock.patch`) |
| `from time import sleep` at module top level | ✅ **new** |
| `from asyncio import sleep` at module top level | ✅ **new** |
| `_sleep = time.sleep` inside a function body | ❌ not visible in `sys.modules` |

### Key implementation details

- `_ORIG_TIME_SLEEP` / `_ORIG_ASYNCIO_SLEEP` captured at **import time** (before any mock can replace them) — identity anchors for the scan.
- `sleepfake.core` itself is excluded from the scan to avoid overwriting those sentinels.
- The `ignore` list is respected: modules matching any prefix in `_ignore` (e.g. `_pytest.timing`, `pytest_timeout`) keep their real sleep references — mirrors freezegun's `mod_name.startswith(self.ignore)` guard.
- `warnings.catch_warnings()` wraps the inner loop to suppress deprecation noise from C-extension descriptors.

### Changes

| File | Change |
|---|---|
| `src/sleepfake/core.py` | + `import time as _time_module`, `types`, `warnings`; `_ORIG_*` sentinels; `_patch_module_aliases()` / `_unpatch_module_aliases()`; wired into `__enter__`, `__exit__`, `aclose`; updated class docstring Note |
| `tests/test_sync.py` | + 3 tests: module alias patched, alias restored on exception, local variable NOT patched |
| `tests/test_async.py` | + 1 test: `from asyncio import sleep` alias patched |
| `README.md` | Updated "⚠️ Scope limitation" section and "How it works" table |

### Tests

```
64 passed in 4.4s
```

ruff ✅  mypy (strict) ✅
